### PR TITLE
Require local_mode library

### DIFF
--- a/script/launch-zero
+++ b/script/launch-zero
@@ -2,6 +2,7 @@
 
 require 'chef'
 require 'fileutils'
+require 'chef/local_mode'
 
 current_dir = File.dirname(__FILE__)
 repo_directory = File.join(current_dir, '..', 'chef-zero-local')


### PR DESCRIPTION
Fixes #2

When `script/launch_zero` was created, this require was not needed. It's not clear when Chef changed, but this should resolve the issue reported in #2.